### PR TITLE
Chg-ch3-gainstage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+
+All notable changes to this project will be documented in this file.
+
+This project follows the `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
+
+All dates should follow the `ISO standard <https://www.iso.org/iso/home/standards/iso8601.htm>`_.
+
+
+## 0.1.2 - (2023-09-20)
+
+### Changed
+- ch3 gainstage set to external input for both chips, allowing the laser pulse to be digitized with the laser return.
+
+## 0.1.1 - (2022-12-01)
+
+### Changed
+- initial

--- a/oleas/helpers.py
+++ b/oleas/helpers.py
@@ -216,4 +216,4 @@ def set_default_gain_stages(board):
         gc.ch0_external_input()
         gc.ch1_8x_ch0()
         gc.ch2_8x_ch1()
-        gc.ch3_8x_ch2() # use of channel 3 isn't planned, but might come in handy
+        gc.ch3_external_input() # use of channel 3 isn't planned, but might come in handy

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 
 setuptools.setup(
-    version="0.1.1",
+    version="0.1.2",
     name="oleas",
     description="OLEAS readout",
     python_requires=">=3.9",


### PR DESCRIPTION
### Problem

The system has jidder between digitizer and laser firing, making it hard to tune the gated PMT.

### Proposal

Digitize the laser trigger signal using ch3 (which has too much gain to be useful  for the  laser response at this stage).